### PR TITLE
Removes Semaphore from Janrain to Make Requests Asynchronous

### DIFF
--- a/Janrain/JRConnectionManager/JRConnectionManager.m
+++ b/Janrain/JRConnectionManager/JRConnectionManager.m
@@ -187,8 +187,6 @@ static JRConnectionManager *singleton = nil;
 
     if (![NSURLConnection canHandleRequest:request])
         return NO;
-    
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
 
     __block NSURLSessionTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -208,8 +206,6 @@ static JRConnectionManager *singleton = nil;
             
         
         });
-        dispatch_semaphore_signal(semaphore);
-        
     }];
 
     if (!task)
@@ -223,8 +219,6 @@ static JRConnectionManager *singleton = nil;
     [connectionBuffers addObject:connectionData];
     [task resume];
     [connectionManager startActivity];
-
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
     
     return YES;
 }


### PR DESCRIPTION
## What it Does

This pull request attempts to fix the use of synchronous URL requests everywhere, but most concerningly on startup from simply calling `setClientConfig` as recommended. I believe that this conversion should be safe because the semaphore causing the request to run synchronously was added when replacing usage of `NSURLConnection` with `NSURLSession`, and it seems that there were minimal overall logical changes to the `NSURLConnection` implementation, which was asynchronous.

## Notes

- This was originally completed by @bcapps 