### PR TITLE
Fix bug with urlencode of '+' and '&'.

### DIFF
--- a/Janrain/JRConnectionManager/JRConnectionManager.m
+++ b/Janrain/JRConnectionManager/JRConnectionManager.m
@@ -41,7 +41,9 @@
 @implementation NSString (JRString_UrlEscaping)
 - (NSString *)stringByAddingUrlPercentEscapes
 {
-    NSString *encodedString = [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+    NSMutableCharacterSet *allowed = [[NSCharacterSet URLQueryAllowedCharacterSet] mutableCopy];
+    [allowed removeCharactersInString:@"?+=&"];
+    NSString *encodedString = [self stringByAddingPercentEncodingWithAllowedCharacters:allowed];
 
     return encodedString;
 }


### PR DESCRIPTION
Fixes janrain/jump.ios#55

`(NSString *)stringByAddingUrlPercentEscapes` did not encode `+` or `&`. These characters are included in `[NSCharacterSet URLQueryAllowedCharacterSet]` because that character set is intended to be used with a full query URL component. However, these characters must be removed from the `NSCharacterSet` to properly encode query string key/value pairs.

This method is used to manually assemble a URL query component from key/value pairs with `[NSString stringWithFormat:@"key=%@", value]`. An unescaped `+` character in the value would be interpreted as a space in the request, and an unescaped `&` would cut the value short (e.g. `foo=bar&baz` effectively became `foo=bar`). Thus it was not possible to authenticate using a password that contained a plus or an ampersand. This issue affects all Capture API fields, but `+` and `&` are most likely to appear in passwords, particularly those generated by password managers.

Although not strictly necessary to fix this bug, it seemed prudent to also URL escape `=` and `?`. These characters would likely never be present in the key of a key-value parameter sent to the API, but encoding them guarantees a well-formed query parameter string.